### PR TITLE
switch to codecov bash uploader

### DIFF
--- a/step.sh
+++ b/step.sh
@@ -2,6 +2,4 @@
 
 set -e
 
-curl https://bootstrap.pypa.io/get-pip.py | python
-PYTHONUSERBASE=./ pip install --user --ignore-installed codecov
-PYTHONUSERBASE=./ ./bin/codecov --token=$CODECOV_TOKEN
+bash <(curl -s https://codecov.io/bash)


### PR DESCRIPTION
the toke is not needed as its detected at `$CODECOV_TOKEN` automatically
